### PR TITLE
chore(npm): Babelize the lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 docs
+# Compiled lib directory
+lib

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "json-document",
   "version": "0.0.0",
   "description": "",
-  "main": "src/index.js",
+  "main": "lib/index",
   "scripts": {
-    "test": "mocha -w",
+    "build": "babel src -d lib",
+    "postinstall": "npm run build",
+    "prepublish": "npm test && npm run build",
+    "test": "mocha",
     "karma": "karma start",
     "jsdoc": "jsdoc -c jsdoc.json -r"
   },
@@ -21,7 +24,6 @@
   "devDependencies": {
     "babel-core": "^6.11.4",
     "babel-loader": "^6.2.4",
-    "babel-preset-es2015": "^6.9.0",
     "benchmark": "^2.1.0",
     "chai": "^3.5.0",
     "json-schema-test-suite": "0.0.10",
@@ -31,5 +33,9 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.5.3",
     "webpack": "^1.13.1"
+  },
+  "dependencies": {
+    "babel-cli": "^6.16.0",
+    "babel-preset-es2015": "^6.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "description": "",
   "main": "lib/index",
+  "files": [
+    "src",
+    "lib"
+  ],
   "scripts": {
     "build": "babel src -d lib",
     "postinstall": "npm run build",


### PR DESCRIPTION
In preparation for Webpack
- Add a 'prepublish' and 'postinstall' npm scripts
- Point package main to /lib/index
